### PR TITLE
fix: add fancybox scripts to fix magazine bug

### DIFF
--- a/wp-content/themes/thestanforddaily/functions.php
+++ b/wp-content/themes/thestanforddaily/functions.php
@@ -141,6 +141,9 @@ function tsd_scripts() {
 		wp_enqueue_style( 'slick-carousel-css', 'https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.css' );
 		wp_enqueue_style( 'slick-carousel-theme-css', 'https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick-theme.css' );
 		wp_enqueue_script( 'slick-carousel', 'https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.min.js', array('jquery'));
+
+		wp_enqueue_style( 'fancybox-style', 'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.2/dist/jquery.fancybox.min.css');
+		wp_enqueue_script('fancybox-script', 'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.2/dist/jquery.fancybox.min.js', array('jquery'));
 	}
 }
 add_action( 'wp_enqueue_scripts', 'tsd_scripts' );

--- a/wp-content/themes/thestanforddaily/functions.php
+++ b/wp-content/themes/thestanforddaily/functions.php
@@ -142,8 +142,8 @@ function tsd_scripts() {
 		wp_enqueue_style( 'slick-carousel-theme-css', 'https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick-theme.css' );
 		wp_enqueue_script( 'slick-carousel', 'https://cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.min.js', array('jquery'));
 
-		wp_enqueue_style( 'fancybox-style', 'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.2/dist/jquery.fancybox.min.css');
-		wp_enqueue_script('fancybox-script', 'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.2/dist/jquery.fancybox.min.js', array('jquery'));
+		wp_enqueue_style( 'fancybox-style', 'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.6/dist/jquery.fancybox.min.css' );
+		wp_enqueue_script( 'fancybox-script', 'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.6/dist/jquery.fancybox.min.js', array('jquery') );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'tsd_scripts' );


### PR DESCRIPTION
On magazine page, when you click on a magazine in the magazine slider (https://www.stanforddaily.com/category/magazine/), nothing shows up.

This is because the fancybox scripts are missing.