### PR TITLE
fix: cache bust theme styles and scripts

### DIFF
--- a/wp-content/themes/thestanforddaily/functions.php
+++ b/wp-content/themes/thestanforddaily/functions.php
@@ -121,15 +121,15 @@ add_action( 'widgets_init', 'tsd_widgets_init' );
  */
 function tsd_scripts() {
 	//wp_enqueue_style( 'tsd-style', get_stylesheet_uri() );
-	wp_enqueue_style( 'tsd-style', get_stylesheet_directory_uri() . "/style.min.css", array(), filemtime(get_template_directory() . '/style.min.css') );
+	wp_enqueue_style( 'tsd-style', get_stylesheet_directory_uri() . "/style.min.css", array(), filemtime( get_template_directory() . '/style.min.css' ) );
 	wp_enqueue_style( 'load-fa', 'https://use.fontawesome.com/releases/v5.6.3/css/all.css' );
 	wp_enqueue_style( 'load-google-fonts', 'https://fonts.googleapis.com/css?family=Open+Sans|Libre+Baskerville|PT+Serif:400,400i,700' );
 	wp_enqueue_style( 'bootstrap-grid', 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-grid.min.css' );
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'tsd-navigation', get_template_directory_uri() . '/js/navigation.js', array(), filemtime(get_template_directory() . '/js/navigation.js'), true );
-	wp_enqueue_script( 'tsd-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), filemtime(get_template_directory() . '/js/skip-link-focus-fix.js'), true );
-	wp_enqueue_script( 'tsd-donation-banner-and-tips-widget', get_template_directory_uri() . '/js/donation-banner-and-tips-widget.js', array(), filemtime(get_template_directory() . '/js/donation-banner-and-tips-widget.js'), true );
+	wp_enqueue_script( 'tsd-navigation', get_template_directory_uri() . '/js/navigation.js', array(), filemtime( get_template_directory() . '/js/navigation.js' ), true );
+	wp_enqueue_script( 'tsd-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), filemtime( get_template_directory() . '/js/skip-link-focus-fix.js' ), true );
+	wp_enqueue_script( 'tsd-donation-banner-and-tips-widget', get_template_directory_uri() . '/js/donation-banner-and-tips-widget.js', array(), filemtime( get_template_directory() . '/js/donation-banner-and-tips-widget.js' ), true );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		// We are using Disqus

--- a/wp-content/themes/thestanforddaily/functions.php
+++ b/wp-content/themes/thestanforddaily/functions.php
@@ -121,15 +121,15 @@ add_action( 'widgets_init', 'tsd_widgets_init' );
  */
 function tsd_scripts() {
 	//wp_enqueue_style( 'tsd-style', get_stylesheet_uri() );
-	wp_enqueue_style( 'tsd-style', get_stylesheet_directory_uri() . "/style.min.css" );
+	wp_enqueue_style( 'tsd-style', get_stylesheet_directory_uri() . "/style.min.css", array(), filemtime(get_template_directory() . '/style.min.css') );
 	wp_enqueue_style( 'load-fa', 'https://use.fontawesome.com/releases/v5.6.3/css/all.css' );
 	wp_enqueue_style( 'load-google-fonts', 'https://fonts.googleapis.com/css?family=Open+Sans|Libre+Baskerville|PT+Serif:400,400i,700' );
 	wp_enqueue_style( 'bootstrap-grid', 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-grid.min.css' );
 
 	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'tsd-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20151215', true );
-	wp_enqueue_script( 'tsd-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
-	wp_enqueue_script( 'tsd-donation-banner-and-tips-widget', get_template_directory_uri() . '/js/donation-banner-and-tips-widget.js', array(), '20190301', true );
+	wp_enqueue_script( 'tsd-navigation', get_template_directory_uri() . '/js/navigation.js', array(), filemtime(get_template_directory() . '/js/navigation.js'), true );
+	wp_enqueue_script( 'tsd-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), filemtime(get_template_directory() . '/js/skip-link-focus-fix.js'), true );
+	wp_enqueue_script( 'tsd-donation-banner-and-tips-widget', get_template_directory_uri() . '/js/donation-banner-and-tips-widget.js', array(), filemtime(get_template_directory() . '/js/donation-banner-and-tips-widget.js'), true );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		// We are using Disqus


### PR DESCRIPTION
This way, when we update any css or js, the changes will be reflected immediately to the end-user (as opposed to making them clear their cache, or our changing the string in the enqueue scripts).