### PR TITLE
Add TSD Push Notification Plugin as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = wp-content/plugins/wp-libre-form
 	url = https://github.com/libreform/wp-libre-form.git
 	branch = master
+[submodule "wp-content/plugins/tsd-push-notification"]
+	path = wp-content/plugins/tsd-push-notification
+	url = https://github.com/TheStanfordDaily/tsd-push-notification.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ https://github.com/TheStanfordDaily/stanforddaily-website/wiki/Setting-up-the-St
 We use submodules to track plugin dependencies from Github. WPEngine supports using submodules; that way we won't have to make copies of all the plugin files in code!
 ```
 # add submodule to track master branch
-git submodule add -b master [URL to Git repo];
+git submodule add -b master [URL to Git repo] [sub-directory path]
+
+# for example: adding a plugin to the `wp-content/plugins/` folder
+git submodule add -b master https://github.com/TheStanfordDaily/tsd-push-notification.git wp-content/plugins/tsd-push-notification
 
 # update your submodule
-git submodule update --remote 
+git submodule update --remote
 ```


### PR DESCRIPTION
Since we moved #165 to a separate repo [TheStanfordDaily/tsd-push-notification](https://github.com/TheStanfordDaily/tsd-push-notification), we will now add the plugin as a submodule.